### PR TITLE
feat: add fish shell support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -251,6 +251,7 @@ impl ShellConfigCommand {
                 contents.push_str(include_str!("shell_configs/pxh.bash"));
                 contents
             }
+            "fish" => String::from(include_str!("shell_configs/pxh.fish")),
             _ => {
                 return Err(Box::from(format!(
                     "Unsupported shell: {} (PRs welcome!)",
@@ -270,6 +271,7 @@ impl InstallCommand {
         let rc_file = match shellname {
             "zsh" => ".zshrc",
             "bash" => ".bashrc",
+            "fish" => ".config/fish/config.fish",
             _ => return Err(Box::from(format!("Unsupported shell: {shellname} (PRs welcome!)"))),
         };
 

--- a/src/shell_configs/pxh.fish
+++ b/src/shell_configs/pxh.fish
@@ -1,0 +1,45 @@
+function _pxh_preexec --on-event fish_preexec
+    set -l cmd $argv[1]
+    if test -z "$cmd"
+        return 1
+    end
+    set -l started (date +%s)
+    pxh \
+        --db $PXH_DB_PATH \
+        insert \
+        --working-directory $PWD \
+        --hostname $PXH_HOSTNAME \
+        --shellname fish \
+        --username $USER \
+        --session-id $PXH_SESSION_ID \
+        --start-unix-timestamp $started \
+        $cmd
+end
+
+function _pxh_postexec --on-event fish_postexec
+    set -l retval $status
+    set -l ended (date +%s)
+    pxh \
+        --db $PXH_DB_PATH \
+        seal \
+        --session-id $PXH_SESSION_ID \
+        --end-unix-timestamp $ended \
+        --exit-status $retval
+end
+
+function _pxh_random
+    # Generate a random session ID using fish's random function
+    echo (random)(random)(random)(random)
+end
+
+function _pxh_init
+    set -gx PXH_SESSION_ID (_pxh_random)
+    set -gx PXH_HOSTNAME (hostname -s)
+    set -gx PXH_DB_PATH (test -n "$PXH_DB_PATH"; and echo $PXH_DB_PATH; or echo $HOME/.pxh/pxh.db)
+
+    if not test -d (dirname $PXH_DB_PATH)
+        mkdir -p -m 0700 (dirname $PXH_DB_PATH)
+    end
+end
+
+_pxh_init


### PR DESCRIPTION
This PR adds fish shell support to pxhist, allowing users to track command history in fish shells.

## Changes
- Add fish shell configuration with event-based command tracking
- Update InstallCommand to support fish config file path
- Update ShellConfigCommand to include fish configuration

## Usage
Users can now install fish shell support:
```bash
pxh install fish
```

Closes #4

Generated with [Claude Code](https://claude.ai/code)