### PR TITLE
ci: bump MSRV to 1.95 for cfg_select! in libsqlite3-sys 0.38

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Install MSRV Rust
       uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: "1.88"
+        toolchain: "1.95"
 
     - name: Cache cargo registry
       uses: actions/cache@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "pxh"
 version = "0.9.25"
 edition = "2024"
-rust-version = "1.88"
+rust-version = "1.95"
 authors = [ "Chip Turner <cturner@pattern.net>" ]
 description = """
 pxh is a fast, cross-shell history mining tool with interactive fuzzy search,


### PR DESCRIPTION
## Problem

The `msrv` job in the Rust workflow is failing on `main`:

```
error: cannot find macro `cfg_select` in this scope
 --> libsqlite3-sys-0.38.0/build.rs:110:9
```

`libsqlite3-sys 0.38.0` (transitive via `rusqlite`, bundled SQLite) uses the `cfg_select!` macro in its build script. That macro was [stabilized in Rust 1.95](https://lwn.net/Articles/1068011/), so the dependency no longer compiles under the pinned MSRV of 1.88. The regular `test` jobs (stable toolchain) and the release builds were unaffected, which is why only the MSRV job went red.

## Fix

Bump MSRV from 1.88 → 1.95 (the floor where the dependency compiles) in both places that declare it:
- `Cargo.toml` `rust-version`
- `.github/workflows/rust.yml` toolchain pin

Verified locally with `cargo build --locked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)